### PR TITLE
Support upstream automated installation on CentOS/RHEL 7 using podman

### DIFF
--- a/install/roles/start_postgres_common/tasks/main.yml
+++ b/install/roles/start_postgres_common/tasks/main.yml
@@ -23,6 +23,7 @@
   shell: "{{ container_command }} run --name {{ db_name }}  -e POSTGRES_USER={{dbms_user}} -e POSTGRES_PASSWORD={{dbms_password}} -v db-data:/var/lib/postgresql/data -d postgres:{{POSTGRES_VERSION}}"
   become: true
   when:
+    - container_command == 'docker'
     - is_rhel_centos_7|bool
 
 - name: Waiting for Postgres to spin up


### PR DESCRIPTION
To test, run the following command on RHEL 7:

```
cd /quipucords_installer; sudo su
make offline-prep
yum install -y podman
./quipucords-installer -e container_command=podman
```

closes #73 