### PR TITLE
Fix misspelling in the man.rst

### DIFF
--- a/docs/man.rst
+++ b/docs/man.rst
@@ -10,7 +10,7 @@ quipucords-installer - Installs the Quipucords server and command line interface
 Synopsis
 --------
 
-``quipiucords-installer [options]``
+``quipucords-installer [options]``
 
 Description
 -----------


### PR DESCRIPTION
Fix a misspelling that was brought to my attention using the sed replacement for discovery downstream. 