### PR TITLE
build: update BuildRequires and Requires in spec file to reflect actual requirements

### DIFF
--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -1,6 +1,6 @@
 %global product_name_lower quipucords
 %global product_name_title Quipucords
-%global version_installer 1.9.1
+%global version_installer 1.9.2
 %global server_image quay.io/quipucords/quipucords:1.9
 %global ui_image quay.io/quipucords/quipucords-ui:latest
 
@@ -86,6 +86,9 @@ sed -i 's#^Image=.*#Image=%{ui_image}#g' %{buildroot}/%{_datadir}/%{name}/config
 %{_datadir}/%{name}/env/env-server.env
 
 %changelog
+* Thu Aug 1 2024 Brad Smith <brasmith@redhat.com> - 0:1.9.2-1
+- Add missing BuildRequires and Requires.
+
 * Mon Jul 22 2024 Brad Smith <brasmith@redhat.com> - 0:1.8.1-1
 - Update names and fix typos in spec file.
 

--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -17,6 +17,9 @@ Source0:        %{url}/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 
+BuildRequires:  coreutils
+BuildRequires:  sed
+
 Requires:       bash
 Requires:       coreutils
 Requires:       diffutils

--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -18,6 +18,12 @@ Source0:        %{url}/archive/%{version}.tar.gz
 BuildArch:      noarch
 
 Requires:       bash
+Requires:       coreutils
+Requires:       diffutils
+Requires:       grep
+Requires:       podman
+Requires:       sed
+Requires:       systemd
 
 %description
 %{name} configures and installs the %{product_name_title} server to be


### PR DESCRIPTION
~I don't know exactly what the real minimum versions of each requirement are. So, assuming that RHEL8 is our minimum supported environment, I used the versions that are currently provided by RHEL8.~

No more minimum versions. Consensus from the dev team is any version is probably good enough.