### PR TITLE
Use podman info for cgroups version detection

### DIFF
--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -38,11 +38,11 @@ check_prereqs() {
     fi
   done
 
-  if [[ $(stat -fc %T /sys/fs/cgroup/) != "cgroup2fs" ]]; then
+  if [[ "$(podman info --format "{{.Host.CgroupsVersion}}")" != "v2" ]]; then
     cat <<EOFDOC >&2
-Error: cgroup2fs is required but is not currently available.
+Error: system is not configured to use cgroups v2.
 
-To enable cgroup2fs (a.k.a. "cgroups-v2"), you may need to
+To enable cgroups v2 (a.k.a. cgroup2fs), you may need to
 update your kernel arguments and reboot. Consider running
 these commands before trying to use quipucords-installer:
 


### PR DESCRIPTION
There are gazillion ways to detect if you have cgroups v1 or v2. Since we want v2 because we want to use quadlet, which is part of podman, it seems the best choice we can make is to trust podman. At the end of the day, if podman thinks it is running v1, then quadlet will likely not work - and it doesn't matter what other tools report.

`CgroupsVersion` [string capitalization changed in Podman 4.0](https://github.com/containers/podman/commit/a15dfb3648b903fa61c299347b315ad8302d8e15). In other words, this command will fail on Podman 3.x. Podman 4.0 is available since RHEL 8.5 or so. Quadlet is only available since Podman 4.4.