### PR TITLE
fix: improve errors and instructional messages

### DIFF
--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -359,12 +359,12 @@ pull_latest_images() {
     image=$(grep -o '^Image=.*' "$systemd_container" | tail -n 1 | sed 's/^Image=//')
     echo "Pulling the latest version of '$image'"
     if ! podman pull -q "$image" &>/dev/null; then
-      echo "Error: Could not pull '$image'." >&2
+      echo "Warning: Could not pull '$image'." >&2
       exit_status=1
     fi
   done
   if [ $exit_status -ne 0 ]; then
-    echo "At least one image failed to pull. Check network connectivity and try again, or manually import the images before starting Quipucords." >&2
+    echo "At least one image failed to pull. Check network connectivity and try again, or manually import the images before starting Quipucords. If you are installing in a disconnected environment and you have already pulled the latest images, you may ignore these warnings." >&2
   fi
   return $exit_status
 }

--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -139,14 +139,28 @@ main() {
   case "$COMMAND" in
   install)
     install
-    echo "Quipucords Installed."
+    cat <<EOFDOC
+Install complete.
+
+You may now start Quipucords by running the following command:
+
+    systemctl --user start quipucords-app
+
+EOFDOC
     exit 0
     ;;
   upgrade)
     upgrade
     upgrade_status=$?
     if [ $upgrade_status -eq 0 ]; then
-      echo "Upgrade complete. You may now start Quipucords."
+      cat <<EOFDOC
+Upgrade complete.
+
+You may now start Quipucords by running the following command:
+
+    systemctl --user start quipucords-app
+
+EOFDOC
     fi
     exit $upgrade_status
     ;;

--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -47,6 +47,7 @@ update your kernel arguments and reboot. Consider running
 these commands before trying to use quipucords-installer:
 
 $ sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=1"
+$ mkdir -p ~/.config/containers
 $ cat << EOF >>~/.config/containers/containers.conf
 [containers]
 pids_limit=0


### PR DESCRIPTION
- clarify "error" messages when image pulls fail
- suggest mkdir before writing containers.conf
- add instructions to start quipucords-app after install or upgrade

As discussed on documentation call on 2024-09-13.

Relates to JIRA: DISCOVERY-612