### PR TITLE
build: update server_image to 1.10

### DIFF
--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -1,7 +1,7 @@
 %global product_name_lower quipucords
 %global product_name_title Quipucords
 %global version_installer 1.10.0
-%global server_image quay.io/quipucords/quipucords:1.9
+%global server_image quay.io/quipucords/quipucords:1.10
 %global ui_image quay.io/quipucords/quipucords-ui:latest
 
 Name:           %{product_name_lower}-installer


### PR DESCRIPTION
Probably hold this PR until the `quipucords` `1.10` tag and image actually exist. Otherwise, the image will not be available and the installation will fail to start.