### PR TITLE
Set --pids-limit explicitly

### DIFF
--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -47,17 +47,7 @@ update your kernel arguments and reboot. Consider running
 these commands before trying to use quipucords-installer:
 
 $ sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=1"
-$ mkdir -p ~/.config/containers
-$ cat << EOF >>~/.config/containers/containers.conf
-[containers]
-pids_limit=0
-EOF
 $ sudo reboot
-
-For more information, please see:
-
-  https://issues.redhat.com/browse/RHEL-5870
-  https://access.redhat.com/solutions/5913671
 
 EOFDOC
     exit 1

--- a/config/quipucords-app.container
+++ b/config/quipucords-app.container
@@ -20,6 +20,9 @@ Network=quipucords.network
 # volume and write nginx logs to the common log volume,
 # let's make sure we map the nginx user to the host's user.
 UserNS=keep-id:uid=1001,gid=1001
+# RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
+# in fact causes us to ignore user settings, if any.
+PidsLimit=0
 
 [Service]
 Restart=always

--- a/config/quipucords-celery-worker.container
+++ b/config/quipucords-celery-worker.container
@@ -17,6 +17,9 @@ Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+# RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
+# in fact causes us to ignore user settings, if any.
+PidsLimit=0
 
 [Service]
 TimeoutStartSec=300

--- a/config/quipucords-db.container
+++ b/config/quipucords-db.container
@@ -18,6 +18,9 @@ Network=quipucords.network
 # [1] https://github.com/sclorg/postgresql-container/blob/1a91d2fd3842a166fff398ce732de7790d55881e/12/Dockerfile.rhel8#L88
 # [2] https://github.com/sclorg/postgresql-container/blob/1a91d2fd3842a166fff398ce732de7790d55881e/12/root/usr/libexec/fix-permissions
 UserNS=keep-id:uid=26,gid=26
+# RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
+# in fact causes us to ignore user settings, if any.
+PidsLimit=0
 
 [Service]
 TimeoutStartSec=300

--- a/config/quipucords-redis.container
+++ b/config/quipucords-redis.container
@@ -9,6 +9,9 @@ Image=registry.redhat.io/rhel9/redis-6:latest
 ExposeHostPort=6379
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 Network=quipucords.network
+# RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
+# in fact causes us to ignore user settings, if any.
+PidsLimit=0
 
 [Service]
 TimeoutStartSec=300

--- a/config/quipucords-server.container
+++ b/config/quipucords-server.container
@@ -19,6 +19,9 @@ Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+# RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
+# in fact causes us to ignore user settings, if any.
+PidsLimit=0
 
 [Service]
 Restart=always


### PR DESCRIPTION
On RHEL 8, you have to set --pids-limit explicitly, or containers fail to start. This can be done in command line or through one of many supported `containers.conf` files. However, our installer is the only place where we tell users this is necessary, and the message is hidden behind a check for cgroups v2 - but you _can_ have cgroups v2 without `containers.conf`, and then nothing is stopping you from starting containers that will not work.