### PR TITLE
chore: set minimum podman version

### DIFF
--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -25,7 +25,7 @@ Requires:       coreutils
 Requires:       diffutils
 Requires:       gawk
 Requires:       grep
-Requires:       podman
+Requires:       podman>=4.7.0
 Requires:       sed
 
 %description


### PR DESCRIPTION
Set the minimum podman version that should provide all features required to run quipucords containers