### PR TITLE
fix: fix broken podman version definition

### DIFF
--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -25,7 +25,7 @@ Requires:       coreutils
 Requires:       diffutils
 Requires:       gawk
 Requires:       grep
-Requires:       podman>=4.7.0
+Requires:       podman >= 4.7.0
 Requires:       sed
 
 %description


### PR DESCRIPTION
Before this fix, any attempt to install the built RPM would fail with an error like this:

```
error: Failed dependencies:
	podman>=4.7.0 is needed by quipucords-installer-0:1.10.0-1.fc40.noarch
```

Or like this:

```
Error: 
 Problem: conflicting requests
  - nothing provides podman>=4.7.0 needed by quipucords-installer-1.10.0-1.20241009182456537194.main.2.g5558630.el9.noarch from @commandline
```

There must be spaces between the package name, `>=` operand, and version. Otherwise, RPM thinks the package name is `podman>=4.7.0`. Thanks to @ruda for spotting this!