### PR TITLE
Run rpmlint in Actions to catch mistakes like one in 5558630f

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
-      - run: sudo apt-get install -y shellcheck
+      - run: sudo apt-get install -y shellcheck rpmlint
       - name: run shellcheck
         run: shellcheck ./bin/*
       - name: run shfmt
         run: shfmt -i 2 --diff ./bin/*
-
+      - name: run rpmlint
+        env:
+          RPMLINT_EXTRA_CONF: "nobuild.rpmlint.toml"
+        run: |
+          echo 'Filters = ["no-%build-section", "no-cleaning-of", "no-buildroot-tag"]' > "$RPMLINT_EXTRA_CONF"
+          rpmlint -c "$RPMLINT_EXTRA_CONF" -s quipucords-installer.spec


### PR DESCRIPTION
[rpmlint](https://github.com/rpm-software-management/rpmlint) is a bit peculiar. If I run it against spec from 5558630f5bedec5a425bfbc854440b7a098515a8 it will **warn** about lack of spaces, but still consider it fine:

```
$ rpmlint quipucords-installer.spec
==================================================================== rpmlint session starts ===================================================================
rpmlint: 2.5.0
...
quipucords-installer.spec: W: no-%build-section
quipucords-installer.spec:28: W: comparison-operator-in-deptoken podman>=4.7.0
=============================== 0 packages and 1 specfiles checked; 0 errors, 2 warnings, 1 filtered, 0 badness; has taken 0.1 s ==============================
$ echo $?
0
```

I can use `-s`, `--strict` flag to turn all warnings into errors, but then we will get pipeline that always fail due to that `no-%build-section`.

So in Actions I'm telling rpmlint to ignore `no-%build-section`, but consider everything else an error.

rpmlint is Python program. I decided to use package from Ubuntu repositories, which generally lags behind upstream a bit (Ubuntu 24.04 has 2.5.0, upstream is now on 2.6.1). But upstream does not see very active development and releases no more than 2-3 times a year, so I don't think we are losing much. We can always switch to rpmlint from PyPI.

rpmlint warns that it runs different checks for spec files, source RPMs and binary RPMs; they recommend running the tool against all artifacts for greatest coverage. But our RPMs are built by packit, so we would have to ask packit to run rpmlint against them, and this is where I draw the line.