### PR TITLE
Fix env file overrides

### DIFF
--- a/bin/quipucords-installer
+++ b/bin/quipucords-installer
@@ -309,8 +309,9 @@ copy_env() {
     while IFS=$'\n' read -r line; do
       env_var=${line%=*}
       env_val=${line#*=}
-      if ! echo "${env_unit}" | grep "^${env_var}=" >/dev/null; then
-        env_unit="${env_unit//${env_var}=.*/${env_var}=${env_val}/}"
+      if echo "${env_unit}" | grep "^${env_var}=" >/dev/null; then
+        # shellcheck disable=SC2001
+        env_unit="$(echo "${env_unit}" | sed -e "s/^${env_var}=.\+/${env_var}=${env_val}/")"
       else
         NL=$'\n'
         env_unit="${env_unit}${NL}${env_var}=${env_val}"


### PR DESCRIPTION
The logic in conditional was inverted - we checked if there isn't a line starting with a variable name, and if there wasn't, we modified that line. If there was, we added new line.

Parameter pattern substitution takes a shell glob, not regular expression. I tried using different glob and had it working from interactive shell, but not in the script. I ported the entire thing to sed, which is already used elsewhere in the script and works well.