### PR TITLE
chore: set quipucords uid=1001

### DIFF
--- a/config/quipucords-app.container
+++ b/config/quipucords-app.container
@@ -19,7 +19,7 @@ Network=quipucords.network
 # Since we could write self-generated keys to the shared certs
 # volume and write nginx logs to the common log volume,
 # let's make sure we map the nginx user to the host's user.
-UserNS=keep-id:uid=1001,gid=1001
+UserNS=keep-id:uid=1001
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0

--- a/config/quipucords-celery-worker.container
+++ b/config/quipucords-celery-worker.container
@@ -20,6 +20,12 @@ Network=quipucords.network
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0
+# Konflux requires non-root users in container images; for this reason, quipucords-server
+# versions above 1.12.1 shall use user 1001, regardless of being released through Konflux
+# or Brew, to accomodate this change.
+# Mounted volumes are always mapped to root on SELinux, so we need to use UserNS config to
+# set the ownership correctly.
+UserNS=keep-id:uid=1001
 
 [Service]
 TimeoutStartSec=300

--- a/config/quipucords-server.container
+++ b/config/quipucords-server.container
@@ -22,6 +22,12 @@ Network=quipucords.network
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0
+# Konflux requires non-root users in container images; for this reason, quipucords-server
+# versions above 1.12.1 shall use user 1001, regardless of being released through Konflux
+# or Brew, to accomodate this change.
+# Mounted volumes are always mapped to root on SELinux, so we need to use UserNS config to
+# set the ownership correctly.
+UserNS=keep-id:uid=1001
 
 [Service]
 Restart=always


### PR DESCRIPTION
One of Red Hat Enterprise Contract rules enforces that the default user in container images SHOULD NOT be root (0). This requires the use of UserNS to play nice with SELinux volumes.

Relates to JIRA: DISCOVERY-708