### PR TITLE
fix: Don't start app if dependencies failed to start

### DIFF
--- a/config/quipucords-app.container
+++ b/config/quipucords-app.container
@@ -1,10 +1,10 @@
 [Unit]
 Description=Quipucords App
 Requires=podman.socket
-Wants=quipucords-db.service
-Wants=quipucords-redis.service
-Wants=quipucords-celery-worker.service
-Wants=quipucords-server.service
+Requires=quipucords-db.service
+Requires=quipucords-redis.service
+Requires=quipucords-celery-worker.service
+Requires=quipucords-server.service
 After=quipucords-server.service
 
 [Container]


### PR DESCRIPTION
In systemd, `Wants=` is a weak dependency - if this unit is started, then attempt to start referenced units, but if they fail to start, ignore that. systemd recommends this dependency type, possibly thinking about robust services that can gracefully degrade when dependencies are not met, and can start using them on runtime once they become available.

`Requires=` is similar, but if referenced unit fails to start, then this unit will also fail to start. This seems to be a better fit for Discovery, where we can't really do anything without database and redis.

See [systemd docs](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Wants=).

Using `Requires` you can still start dependencies individually, i.e. you can start database, load data and only then continue with other services.

When using `Requires` and one of dependencies can't start (i.e. I use downstream image and do not authenticate to registry):

```
$ systemctl --user start quipucords-app
A dependency job for quipucords-app.service failed. See 'journalctl -xe' for details.
```
```
$ journalctl -xe
...
Apr 01 12:23:44 machine quipucords-redis[35021]: Error: initializing source docker://registry.redhat.io/rhel9/redis-6:latest: unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication
Apr 01 12:23:44 machine systemd[3103]: quipucords-redis.service: Failed with result 'exit-code'.
░░ Subject: Unit failed
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The unit UNIT has entered the 'failed' state with result 'exit-code'.
Apr 01 12:23:44 machine systemd[3103]: Dependency failed for quipucords-app.service - Quipucords App.
░░ Subject: A start job for unit UNIT has failed
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ A start job for unit UNIT has finished with a failure.
░░ 
░░ The job identifier is 1253 and the job result is dependency.
```
```
$ podman ps -a
CONTAINER ID  IMAGE                    COMMAND               CREATED            STATUS            PORTS       NAMES
f749ecd9622f  rhel9-postgresql-15      run-postgresql        About an hour ago  Up About an hour  5432/tcp    quipucords-db
d5a349632910  discovery-server:latest  /bin/bash /deploy...  About an hour ago  Up About an hour  8000/tcp    quipucords-server
4d3ab0d8c58c  discovery-server:latest  /bin/sh -c /deplo...  About an hour ago  Up About an hour  8000/tcp    quipucords-celery-worker
```
```
$ systemctl --user status quipucords-app.service
○ quipucords-app.service - Quipucords App
     Loaded: loaded (/home/mzalewsk/.config/containers/systemd/quipucords-app.container; generated)
    Drop-In: /usr/lib/systemd/user/service.d
             └─10-timeout-abort.conf
             /run/user/102109/systemd/user.control/quipucords-app.service.d
             └─50-CPUWeight.conf, 50-IOWeight.conf
     Active: inactive (dead)

Apr 01 13:12:09 machine systemd[3103]: Stopping quipucords-app.service - Quipucords App...
Apr 01 13:12:19 machine quipucords-app[51870]: time="2025-04-01T13:12:19+02:00" level=warning msg="StopSignal SIGQUIT failed to stop c>
Apr 01 13:12:19 machine podman[51870]: 2025-04-01 13:12:19.652496888 +0200 CEST m=+10.086440474 container died 32f6030c07536ff10da0b42>
Apr 01 13:12:20 machine podman[51870]: 2025-04-01 13:12:20.002802045 +0200 CEST m=+10.436745597 container remove 32f6030c07536ff10da0b>
Apr 01 13:12:20 machine quipucords-app[51870]: 32f6030c07536ff10da0b42c3355adb431df39724652fc7e22c668dd3153dff7
Apr 01 13:12:20 machine systemd[3103]: quipucords-app.service: Main process exited, code=exited, status=137/n/a
Apr 01 13:12:20 machine systemd[3103]: quipucords-app.service: Failed with result 'exit-code'.
Apr 01 13:12:20 machine systemd[3103]: Stopped quipucords-app.service - Quipucords App.
Apr 01 13:13:13 machine systemd[3103]: Dependency failed for quipucords-app.service - Quipucords App.
Apr 01 13:13:13 machine systemd[3103]: quipucords-app.service: Job quipucords-app.service/start failed with result 'dependency'.
```

Relates to JIRA: DISCOVERY-912
