### PR TITLE
build: upgrade from redis-6:latest to redis-7:latest

### DIFF
--- a/config/quipucords-redis.container
+++ b/config/quipucords-redis.container
@@ -5,7 +5,7 @@ PartOf=quipucords-app.service
 
 [Container]
 ContainerName=quipucords-redis
-Image=registry.redhat.io/rhel9/redis-6:latest
+Image=registry.redhat.io/rhel9/redis-7:latest
 ExposeHostPort=6379
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 Network=quipucords.network

--- a/quipucords-installer.spec
+++ b/quipucords-installer.spec
@@ -1,6 +1,6 @@
 %global product_name_lower quipucords
 %global product_name_title Quipucords
-%global version_installer 1.14.0
+%global version_installer 1.14.1
 %global server_image quay.io/quipucords/quipucords:1.14
 %global ui_image quay.io/quipucords/quipucords-ui:1.14
 


### PR DESCRIPTION
For context, I am copying my comment from [this Slack thread](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1746041368627129?thread_ts=1745501306.349009&cid=C02QSNF1UKE) here:

> Quick manual sanity check procedure from a previously running Discovery installation
> ```
> systemctl --user stop discovery-app
> podman rmi registry.redhat.io/rhel9/redis-6:latest
> vim ~/.config/containers/systemd/discovery-redis.container # 6 to 7
> systemctl --user daemon-reload
> podman login registry.redhat.io
> systemctl --user start discovery-app
> # wait for it...
> ```
> …
> ```
> [brasmith@rhel9 ~]$ podman ps | grep discovery-redis
> d6886c3ab311  registry.redhat.io/rhel9/redis-7:latest                   run-redis             35 seconds ago      Up 34 seconds      6379/tcp                                              discovery-redis
> ```
> …
> and then manually poking around in the UI, triggering a scan, and watching it succeed. This seems to indicate jumping 6 to 7 is a safe bet, and this does not surprise me because Redis tends to maintain good compatibility across versions.

Relates to JIRA: DISCOVERY-937