### PR TITLE
feat: preferring to auto-generate Redis and DB passwords

### DIFF
--- a/bin/create-db-password
+++ b/bin/create-db-password
@@ -7,15 +7,52 @@ fi
 
 set -e
 
-read -srp "Enter the new DB server password: " db_pass
-echo
-read -srp "Re-enter the password: " db_pass2
-echo
-if [ ! "${db_pass}" = "${db_pass2}" ]; then
-  echo "Passwords do not match." 1>&2
-  exit 1
-fi
-[[ -z "${db_pass}" ]] && echo "DB password cannot be blank." 1>&2 && exit 1
+set_db_password() {
+  printf '%s' "$1" | podman secret create quipucords-db-password --replace -
+  podman secret ls --filter name=quipucords-db-password
+}
 
-printf '%s' "${db_pass}" | podman secret create quipucords-db-password --replace -
-podman secret ls --filter name=quipucords-db-password
+generate_and_set_password() {
+  local db_pass
+  db_pass=$(head -c 16 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9')
+  set_db_password "${db_pass}"
+}
+
+prompt_and_set_password() {
+  local db_pass
+  read -srp "Enter the new DB server password: " db_pass
+  echo
+  [[ -z "${db_pass}" ]] && echo "The DB server password cannot be blank." >&2 && exit 1
+  read -srp "Re-enter the password: " db_pass2
+  echo
+  [[ ! "${db_pass}" = "${db_pass2}" ]] && echo "DB server passwords do not match." >&2 && exit 1
+  set_db_password "${db_pass}"
+}
+
+generate_or_prompt_password() {
+  while true; do
+    read -rp "Automatically generate a new DB server password? [y/n]: " yn
+    case $yn in
+    [Yy])
+      generate_and_set_password
+      exit
+      ;;
+    [Nn])
+      prompt_and_set_password
+      exit
+      ;;
+    esac
+  done
+}
+
+while getopts "Yy" opt; do
+  case $opt in
+  [Yy])
+    generate_and_set_password
+    exit
+    ;;
+  *) ;;
+  esac
+done
+
+generate_or_prompt_password

--- a/bin/create-redis-password
+++ b/bin/create-redis-password
@@ -5,15 +5,54 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
   return 1
 fi
 
-read -srp "Enter the new Redis server password: " redis_pass
-echo
-read -srp "Re-enter the password: " redis_pass2
-echo
-if [ ! "${redis_pass}" = "${redis_pass2}" ]; then
-  echo "Passwords do not match." 1>&2
-  exit 1
-fi
-[[ -z "${redis_pass}" ]] && echo "Redis password cannot be blank." 1>&2 && exit 1
+set -e
 
-printf '%s' "${redis_pass}" | podman secret create quipucords-redis-password --replace -
-podman secret ls --filter name=quipucords-redis-password
+set_redis_password() {
+  printf '%s' "$1" | podman secret create quipucords-redis-password --replace -
+  podman secret ls --filter name=quipucords-redis-password
+}
+
+generate_and_set_password() {
+  local redis_pass
+  redis_pass=$(head -c 16 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9')
+  set_redis_password "${redis_pass}"
+}
+
+prompt_and_set_password() {
+  local redis_pass
+  read -srp "Enter the new Redis server password: " redis_pass
+  echo
+  [[ -z "${redis_pass}" ]] && echo "The Redis server password cannot be blank." >&2 && exit 1
+  read -srp "Re-enter the password: " redis_pass2
+  echo
+  [[ ! "${redis_pass}" = "${redis_pass2}" ]] && echo "Redis server passwords do not match." >&2 && exit 1
+  set_redis_password "${redis_pass}"
+}
+
+generate_or_prompt_password() {
+  while true; do
+    read -rp "Automatically generate a new Redis server password? [y/n]: " yn
+    case $yn in
+    [Yy])
+      generate_and_set_password
+      exit
+      ;;
+    [Nn])
+      prompt_and_set_password
+      exit
+      ;;
+    esac
+  done
+}
+
+while getopts "Yy" opt; do
+  case $opt in
+  [Yy])
+    generate_and_set_password
+    exit
+    ;;
+  *) ;;
+  esac
+done
+
+generate_or_prompt_password


### PR DESCRIPTION
- Preferring to auto-generate the Redis and DB passwords upon installs if not already defined.
- Provide the user the ability to auto generate to prompt for Redis and DB passwords via the `create-db-password` and `create-redis-password` subcommands.