### PR TITLE
Set the default LogDriver to journald

### DIFF
--- a/config/quipucords-app.container
+++ b/config/quipucords-app.container
@@ -16,6 +16,7 @@ EnvironmentFile=%h/.config/quipucords/env/env-app.env
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/certs:/opt/app-root/certs:z
 Network=quipucords.network
+LogDriver=journald
 # Since we could write self-generated keys to the shared certs
 # volume and write nginx logs to the common log volume,
 # let's make sure we map the nginx user to the host's user.

--- a/config/quipucords-celery-worker.container
+++ b/config/quipucords-celery-worker.container
@@ -19,6 +19,7 @@ Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+LogDriver=journald
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0

--- a/config/quipucords-db.container
+++ b/config/quipucords-db.container
@@ -12,6 +12,7 @@ Environment=POSTGRESQL_DATABASE=qpc
 Volume=%h/.local/share/quipucords/db:/var/lib/pgsql/data:z
 Secret=quipucords-db-password,type=env,target=POSTGRESQL_PASSWORD
 Network=quipucords.network
+LogDriver=journald
 # for some reason podman default user mapping won't map host user to postgres container uid (26)[1]
 # (maybe due to fix-permission script it executes later on [2]), so we fix that setting this up with
 # UserNS.

--- a/config/quipucords-redis.container
+++ b/config/quipucords-redis.container
@@ -10,6 +10,7 @@ ExposeHostPort=6379
 EnvironmentFile=%h/.config/quipucords/env/env-redis.env
 Secret=quipucords-redis-password,type=env,target=REDIS_PASSWORD
 Network=quipucords.network
+LogDriver=journald
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0

--- a/config/quipucords-server.container
+++ b/config/quipucords-server.container
@@ -21,6 +21,7 @@ Volume=%h/.local/share/quipucords/data:/var/data:z
 Volume=%h/.local/share/quipucords/log:/var/log:z
 Volume=%h/.local/share/quipucords/sshkeys:/sshkeys:z
 Network=quipucords.network
+LogDriver=journald
 # RHEL 8 needs --pids-limit flag. This is not necessary on RHEL 9, and
 # in fact causes us to ignore user settings, if any.
 PidsLimit=0


### PR DESCRIPTION
Make sure we set the default LogDriver to journald (i.e. the --log-driver podman run option) to journald.

This is the default for RHEL9 and beyond, but for RHEL8 it is k8s-file. With the journald driver default, we can check the logs even on failed service starts via:

```
$ journalctl --no-pager --user-unit quipucords-<component>
```

Also, for RHEL8, the user needs to be part of the `systemd-journal` group. This can be done as follows:

```
$ sudo usermod -a -G systemd-journal <user>
```
