### PR TITLE
fix: do not use "podman secret create --replace" because it fails on RHEL8

### DIFF
--- a/bin/create-app-secret
+++ b/bin/create-app-secret
@@ -8,7 +8,8 @@ fi
 set -e
 
 set_django_secret_key() {
-  printf '%s' "$1" | podman secret create quipucords-django-secret-key --replace -
+  podman secret rm quipucords-django-secret-key >/dev/null 2>&1 || true
+  printf '%s' "$1" | podman secret create quipucords-django-secret-key -
   podman secret ls --filter name=quipucords-django-secret-key
 }
 

--- a/bin/create-db-password
+++ b/bin/create-db-password
@@ -8,7 +8,8 @@ fi
 set -e
 
 set_db_password() {
-  printf '%s' "$1" | podman secret create quipucords-db-password --replace -
+  podman secret rm quipucords-db-password >/dev/null 2>&1 || true
+  printf '%s' "$1" | podman secret create quipucords-db-password -
   podman secret ls --filter name=quipucords-db-password
 }
 

--- a/bin/create-redis-password
+++ b/bin/create-redis-password
@@ -8,7 +8,8 @@ fi
 set -e
 
 set_redis_password() {
-  printf '%s' "$1" | podman secret create quipucords-redis-password --replace -
+  podman secret rm quipucords-redis-password >/dev/null 2>&1 || true
+  printf '%s' "$1" | podman secret create quipucords-redis-password -
   podman secret ls --filter name=quipucords-redis-password
 }
 

--- a/bin/create-server-password
+++ b/bin/create-server-password
@@ -20,5 +20,6 @@ fi
 for bad_pass in "dscpassw0rd" "qpcpassw0rd"; do
   [[ "${dsc_pass}" == "${bad_pass}" ]] && echo "Password cannot be ${bad_pass}" 1>&2 && exit 1
 done
-printf '%s' "${dsc_pass}" | podman secret create quipucords-server-password --replace -
+podman secret rm quipucords-server-password >/dev/null 2>&1 || true
+printf '%s' "${dsc_pass}" | podman secret create quipucords-server-password -
 podman secret ls --filter name=quipucords-server-password


### PR DESCRIPTION
This is related to and partially reverts 677c0aae8b854b710533e9b3902c92a6f2d559d6

Relates to JIRA: DISCOVERY-1062

## Summary by Sourcery

Bug Fixes:
- Do not use `podman secret create --replace` in create-app-secret, create-db-password, create-redis-password, and create-server-password scripts to ensure compatibility with RHEL8.